### PR TITLE
Invoice improvements: date picker, saved invoice management, FY tools, and API pagination

### DIFF
--- a/clockify-invoice-config.example.json
+++ b/clockify-invoice-config.example.json
@@ -19,7 +19,12 @@
         "name": "Your Company",
         "email": "your.email@gmail.com",
         "abn": "123 456 789",
-        "rate": 70.0
+        "rate": 70.0,
+        "bank_details": {
+            "account_name": "Your Company Pty Ltd",
+            "bsb": "000-000",
+            "account_number": "12345678"
+        }
     },
     "client": {
         "contact": "Ben Howard",

--- a/clockify_invoice/api.py
+++ b/clockify_invoice/api.py
@@ -71,9 +71,18 @@ class ClockifyClient:
         self,
         workspace_id: str,
         user_id: str,
+        page_size: int = 50,
     ) -> list[dict[str, Any]]:
         path = f"workspaces/{workspace_id}/user/{user_id}/time-entries"
-        return self.session.get(path)
+        results: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            page_results = self.session.get(f"{path}?page={page}&page-size={page_size}")
+            results.extend(page_results)
+            if len(page_results) < page_size:
+                break
+            page += 1
+        return results
 
 
 class ClockifyAPIException(Exception):

--- a/clockify_invoice/config.py
+++ b/clockify_invoice/config.py
@@ -5,6 +5,7 @@ import json
 import os
 from typing import Any
 
+from clockify_invoice.invoice import BankDetails
 from clockify_invoice.invoice import Client
 from clockify_invoice.invoice import Company
 
@@ -30,7 +31,12 @@ _SAMPLE_CONFIG = """\
         "name": "Your Company",
         "email": "your.email@gmail.com",
         "abn": "123 456 789",
-        "rate": 70.0
+        "rate": 70.0,
+        "bank_details": {
+            "account_name": "Your Company Pty Ltd",
+            "bsb": "000-000",
+            "account_number": "12345678"
+        }
     },
     "client": {
         "contact": "Ben Howard",
@@ -101,11 +107,23 @@ class Config:
         except ValueError as e:
             raise ConfigError(f"Invalid company rate: {e}")
         else:
+            bank_details = None
+            bank_cfg = _get_company_setting("bank_details", required=False)
+            if bank_cfg and isinstance(bank_cfg, dict):
+                _get_bank_setting = functools.partial(
+                    self._get_setting, cfg=bank_cfg
+                )
+                bank_details = BankDetails(
+                    _get_bank_setting("account_name"),
+                    _get_bank_setting("bsb"),
+                    _get_bank_setting("account_number"),
+                )
             return Company(
                 _get_company_setting("name"),
                 _get_company_setting("email"),
                 _get_company_setting("abn"),
                 rate,
+                bank_details,
             )
 
     def _load_mail_config(self) -> None:

--- a/clockify_invoice/invoice.py
+++ b/clockify_invoice/invoice.py
@@ -140,11 +140,18 @@ class TimeEntry(NamedTuple):
         return self.duration_hours * self.rate
 
 
+class BankDetails(NamedTuple):
+    account_name: str
+    bsb: str
+    account_number: str
+
+
 class Company(NamedTuple):
     name: str
     email: str
     abn: str
     rate: float
+    bank_details: BankDetails | None = None
 
 
 class Client(NamedTuple):

--- a/clockify_invoice/main.py
+++ b/clockify_invoice/main.py
@@ -7,7 +7,6 @@ import pickle
 import zipfile
 from collections.abc import Sequence
 from datetime import date
-from datetime import datetime
 from typing import Any
 from typing import Literal
 
@@ -18,12 +17,12 @@ from flask import render_template
 from flask import request
 from flask import send_file
 from flask import session
-
 from weasyprint import HTML as WeasyHTML
 
 from clockify_invoice.config import Config
 from clockify_invoice.config import ConfigError
 from clockify_invoice.invoice import Invoice
+from clockify_invoice.store import DuplicateInvoiceNumberError
 from clockify_invoice.store import Store
 from clockify_invoice.utils import auth_required
 from clockify_invoice.utils import get_period_dates
@@ -151,7 +150,10 @@ def save() -> werkzeug.wrappers.Response:
         return redirect("/")
     invoice: Invoice = pickle.loads(session["invoice"])
     store: Store = app.config[FLASK_CONFIG_STORE_KEY]
-    store.save_invoice(invoice)
+    try:
+        store.save_invoice(invoice)
+    except DuplicateInvoiceNumberError as e:
+        session["error"] = str(e)
     session["active-tab"] = "form-tab"
     return redirect("/")
 
@@ -259,12 +261,14 @@ def process_invoice() -> str:
     invoices = store.get_invoices(int(form_data["financial-year"]))
     invoices_total = sum(invoice["total"] for invoice in invoices)
     config_str = json.dumps(store.config._config, indent=4)
+    error = session.pop("error", None)
 
     return invoice.html(
         form_data=form_data,
         invoices=invoices,
         invoices_total=invoices_total,
         config=config_str,
+        error=error,
     )
 
 

--- a/clockify_invoice/main.py
+++ b/clockify_invoice/main.py
@@ -39,8 +39,6 @@ logger = logging.getLogger("clockify-invoice")
 app = Flask(__name__)
 
 # Constants
-TODAY = date.today()
-YEARS = tuple(range(TODAY.year, TODAY.year - 5, -1))
 MONTHS = tuple(cal.month_name[1:])
 FLASK_CONFIG_STORE_KEY = "store"
 PDF_MIME_TYPE = "application/pdf"
@@ -48,9 +46,7 @@ PDF_MIME_TYPE = "application/pdf"
 
 @app.template_filter("format_financial_year")
 def format_financial_year(year: int) -> str:
-    start_date = datetime(year, 6, 30)
-    end_date = datetime(year + 1, 7, 1)
-    return f"{start_date.strftime('%Y')}-{end_date.strftime('%y')}"
+    return f"{year}-{(year + 1) % 100:02d}"
 
 
 @app.template_filter("format_date")
@@ -68,7 +64,7 @@ def view_invoice(invoice_id: int) -> str | werkzeug.wrappers.Response:
     invoice, _ = result
     return invoice.html(
         form_data={"display-form": "none"},
-        invoices_total=0,
+        invoices_total=invoice.total,
     )
 
 
@@ -93,6 +89,8 @@ def download_invoice(invoice_id: int) -> werkzeug.wrappers.Response:
 def download_fy(year: int) -> werkzeug.wrappers.Response:
     store: Store = app.config[FLASK_CONFIG_STORE_KEY]
     invoices_with_pdf = store.get_fy_invoices_with_pdf(year)
+    if not invoices_with_pdf:
+        return redirect("/")
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         for invoice, pdf_bytes in invoices_with_pdf:
@@ -112,6 +110,8 @@ def download_fy(year: int) -> werkzeug.wrappers.Response:
 def download_summary(year: int) -> werkzeug.wrappers.Response:
     store: Store = app.config[FLASK_CONFIG_STORE_KEY]
     invoices_with_pdf = store.get_fy_invoices_with_pdf(year)
+    if not invoices_with_pdf:
+        return redirect("/")
     invoices = [inv for inv, _ in invoices_with_pdf]
     grand_total = sum(inv.total for inv in invoices)
     next_yy = f"{(year + 1) % 100:02d}"
@@ -205,15 +205,17 @@ def config() -> werkzeug.wrappers.Response:
 @auth_required
 def process_invoice() -> str:
     store: Store = app.config[FLASK_CONFIG_STORE_KEY]
+    today = date.today()
+    years = tuple(range(today.year, today.year - 5, -1))
     form_data: dict[str, Any] = {
         "months": MONTHS,
-        "years": YEARS,
-        "month": TODAY.month,
-        "year": TODAY.year,
-        "financial-year": TODAY.year - 1,
+        "years": years,
+        "month": today.month,
+        "year": today.year,
+        "financial-year": today.year - 1,
         "display-form": "block",
         "invoice-number": store.get_next_invoice_number(),
-        "invoice-date": TODAY.isoformat(),
+        "invoice-date": today.isoformat(),
         "active-tab": session.get("active-tab") or "form-tab",
     }
 
@@ -229,7 +231,7 @@ def process_invoice() -> str:
     if invoice_date_str:
         invoice_date = date.fromisoformat(str(invoice_date_str))
     else:
-        invoice_date = TODAY
+        invoice_date = today
 
     if "invoice" in session:
         invoice: Invoice = pickle.loads(session["invoice"])
@@ -337,14 +339,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--year",
         type=int,
-        default=TODAY.year,
+        default=date.today().year,
         metavar="INT",
         help="invoice period year (%(default)s) ",
     )
     parser.add_argument(
         "--month",
         type=int,
-        default=TODAY.month,
+        default=date.today().month,
         metavar="INT",
         choices=range(1, 13),
         help="invoice period month between 1-12 (%(default)s)",

--- a/clockify_invoice/main.py
+++ b/clockify_invoice/main.py
@@ -14,9 +14,12 @@ from typing import Literal
 import werkzeug.wrappers
 from flask import Flask
 from flask import redirect
+from flask import render_template
 from flask import request
 from flask import send_file
 from flask import session
+
+from weasyprint import HTML as WeasyHTML
 
 from clockify_invoice.config import Config
 from clockify_invoice.config import ConfigError
@@ -101,6 +104,34 @@ def download_fy(year: int) -> werkzeug.wrappers.Response:
         "application/zip",
         True,
         zip_filename,
+    )
+
+
+@app.route("/summary/<int:year>", methods=["GET"])
+@auth_required
+def download_summary(year: int) -> werkzeug.wrappers.Response:
+    store: Store = app.config[FLASK_CONFIG_STORE_KEY]
+    invoices_with_pdf = store.get_fy_invoices_with_pdf(year)
+    invoices = [inv for inv, _ in invoices_with_pdf]
+    grand_total = sum(inv.total for inv in invoices)
+    next_yy = f"{(year + 1) % 100:02d}"
+    html_string = render_template(
+        "summary.html",
+        year=year,
+        next_yy=next_yy,
+        company_name=store.config.company.name,
+        invoices=invoices,
+        grand_total=grand_total,
+    )
+    pdf_bytes = WeasyHTML(string=html_string).write_pdf()
+    if not pdf_bytes:
+        return redirect("/")
+    filename = f"FY{year}-{next_yy}_Summary.pdf"
+    return send_file(
+        io.BytesIO(pdf_bytes),
+        PDF_MIME_TYPE,
+        True,
+        filename,
     )
 
 

--- a/clockify_invoice/main.py
+++ b/clockify_invoice/main.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 import pickle
+import zipfile
 from collections.abc import Sequence
 from datetime import date
 from datetime import datetime
@@ -52,6 +53,55 @@ def format_financial_year(year: int) -> str:
 @app.template_filter("format_date")
 def format_date(value: date, format: str = "%d/%m/%Y") -> str:
     return value.strftime(format)
+
+
+@app.route("/invoice/<int:invoice_id>", methods=["GET"])
+@auth_required
+def view_invoice(invoice_id: int) -> str | werkzeug.wrappers.Response:
+    store: Store = app.config[FLASK_CONFIG_STORE_KEY]
+    result = store.get_invoice_by_id(invoice_id)
+    if not result:
+        return redirect("/")
+    invoice, _ = result
+    return invoice.html(
+        form_data={"display-form": "none"},
+        invoices_total=0,
+    )
+
+
+@app.route("/download/<int:invoice_id>", methods=["GET"])
+@auth_required
+def download_invoice(invoice_id: int) -> werkzeug.wrappers.Response:
+    store: Store = app.config[FLASK_CONFIG_STORE_KEY]
+    result = store.get_invoice_by_id(invoice_id)
+    if not result:
+        return redirect("/")
+    invoice, pdf_bytes = result
+    return send_file(
+        io.BytesIO(pdf_bytes),
+        PDF_MIME_TYPE,
+        True,
+        invoice.invoice_name,
+    )
+
+
+@app.route("/download_fy/<int:year>", methods=["GET"])
+@auth_required
+def download_fy(year: int) -> werkzeug.wrappers.Response:
+    store: Store = app.config[FLASK_CONFIG_STORE_KEY]
+    invoices_with_pdf = store.get_fy_invoices_with_pdf(year)
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        for invoice, pdf_bytes in invoices_with_pdf:
+            zf.writestr(invoice.invoice_name, pdf_bytes)
+    zip_buffer.seek(0)
+    zip_filename = f"FY{year}-{(year + 1) % 100:02d}_Invoices.zip"
+    return send_file(
+        zip_buffer,
+        "application/zip",
+        True,
+        zip_filename,
+    )
 
 
 @app.route("/delete_invoice/<int:invoice_id>", methods=["POST"])
@@ -132,6 +182,7 @@ def process_invoice() -> str:
         "financial-year": TODAY.year - 1,
         "display-form": "block",
         "invoice-number": store.get_next_invoice_number(),
+        "invoice-date": TODAY.isoformat(),
         "active-tab": session.get("active-tab") or "form-tab",
     }
 
@@ -143,9 +194,16 @@ def process_invoice() -> str:
 
     invoice_number = int(form_data["invoice-number"])
 
+    invoice_date_str = form_data.get("invoice-date")
+    if invoice_date_str:
+        invoice_date = date.fromisoformat(str(invoice_date_str))
+    else:
+        invoice_date = TODAY
+
     if "invoice" in session:
         invoice: Invoice = pickle.loads(session["invoice"])
         invoice.invoice_number = invoice_number
+        invoice.invoice_date = invoice_date
         invoice.period_start = period_start
         invoice.period_end = period_end
         invoice.company = store.config.company
@@ -157,6 +215,7 @@ def process_invoice() -> str:
             store.config.client,
             period_start,
             period_end,
+            invoice_date=invoice_date,
         )
 
     invoice.time_entries = store.get_time_entries(

--- a/clockify_invoice/store.py
+++ b/clockify_invoice/store.py
@@ -33,7 +33,7 @@ _INVOICES_QUERY = """\
 SELECT id, pickle
 FROM invoice
 WHERE period_start >= ?
-    AND period_end <= ?
+    AND period_end < ?
 """
 
 _GET_INVOICE_QUERY = """\
@@ -46,7 +46,7 @@ _GET_FY_INVOICES_PDF_QUERY = """\
 SELECT id, pickle, pdf
 FROM invoice
 WHERE period_start >= ?
-    AND period_end <= ?
+    AND period_end < ?
 """
 
 _DELETE_INVOICE_QUERY = """\
@@ -164,7 +164,7 @@ class Store:
     ) -> list[tuple[Invoice, bytes]]:
         """Return list of (Invoice, pdf_bytes) for a financial year."""
         start_date = datetime.datetime(financial_year, 7, 1)
-        end_date = datetime.datetime(financial_year + 1, 6, 30)
+        end_date = datetime.datetime(financial_year + 1, 7, 1)
         with self.connect() as db:
             rows = db.execute(
                 _GET_FY_INVOICES_PDF_QUERY, (start_date, end_date)
@@ -241,7 +241,7 @@ class Store:
 
     def get_invoices(self, financial_year: int) -> list[dict[str, Any]]:
         start_date = datetime.datetime(financial_year, 7, 1)
-        end_date = datetime.datetime(financial_year + 1, 6, 30)
+        end_date = datetime.datetime(financial_year + 1, 7, 1)
         with self.connect() as db:
             rows = db.execute(_INVOICES_QUERY, (start_date, end_date)).fetchall()
 

--- a/clockify_invoice/store.py
+++ b/clockify_invoice/store.py
@@ -24,7 +24,7 @@ FROM time_entry
 WHERE user = ?
     AND workspace = ?
     AND start_time >= ?
-    AND end_time < ?
+    AND start_time < ?
     AND duration_seconds > 0
 GROUP BY description
 """
@@ -72,18 +72,13 @@ class Store:
         self._create_db_if_not_exists()
         self.config = Config(config_file)
 
-
     def _initialise(self) -> None:
         if not os.path.exists(self.directory):
             os.makedirs(self.directory, exist_ok=True)
-            logger.info(
-                f"Created store directory '{self.directory}'"
-            )
+            logger.info(f"Created store directory '{self.directory}'")
         if not os.path.exists(self.config_file):
             Config.createConfig(self.config_file)
-            logger.info(
-                f"Created config file '{self.config_file}'"
-            )
+            logger.info(f"Created config file '{self.config_file}'")
         logger.info(f"Using store directory: {self.directory}")
 
     @staticmethod

--- a/clockify_invoice/store.py
+++ b/clockify_invoice/store.py
@@ -16,6 +16,11 @@ from clockify_invoice.invoice import TimeEntry
 
 logger = logging.getLogger("clockify-invoice")
 
+
+class DuplicateInvoiceNumberError(Exception):
+    pass
+
+
 _TIME_ENTRIES_QUERY = """\
 SELECT MAX(end_time) AS date
     , description
@@ -133,6 +138,9 @@ class Store:
                     pdf TEXT,
                     pickle TEXT
                 );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_invoice_number
+                    ON invoice(number);
                 """
             )
 
@@ -204,6 +212,18 @@ class Store:
         return entries
 
     def save_invoice(self, invoice: Invoice) -> None:
+        cols = (
+            "number",
+            "date",
+            "period_start",
+            "period_end",
+            "payer",
+            "payee",
+            "total",
+            "paid",
+            "pdf",
+            "pickle",
+        )
         invoice_data = (
             invoice.invoice_number,
             invoice.invoice_date,
@@ -216,22 +236,15 @@ class Store:
             base64.b64encode(invoice.pdf()).decode(),
             base64.b64encode(pickle.dumps(invoice)).decode(),
         )
-        with self.connect() as db:
-            cols = (
-                "number",
-                "date",
-                "period_start",
-                "period_end",
-                "payer",
-                "payee",
-                "total",
-                "paid",
-                "pdf",
-                "pickle",
-            )
-            db.execute(
-                f"INSERT INTO invoice({','.join(cols)}) VALUES(?,?,?,?,?,?,?,?,?,?)",
-                invoice_data,
+        try:
+            with self.connect() as db:
+                db.execute(
+                    f"INSERT INTO invoice({','.join(cols)}) VALUES(?,?,?,?,?,?,?,?,?,?)",  # NOQA: E501
+                    invoice_data,
+                )
+        except sqlite3.IntegrityError:
+            raise DuplicateInvoiceNumberError(
+                f"Invoice number {invoice.invoice_number} already exists"
             )
 
     def get_invoices(self, financial_year: int) -> list[dict[str, Any]]:

--- a/clockify_invoice/store.py
+++ b/clockify_invoice/store.py
@@ -38,7 +38,7 @@ _INVOICES_QUERY = """\
 SELECT id, pickle
 FROM invoice
 WHERE period_start >= ?
-    AND period_end < ?
+    AND period_start < ?
 """
 
 _GET_INVOICE_QUERY = """\
@@ -51,7 +51,7 @@ _GET_FY_INVOICES_PDF_QUERY = """\
 SELECT id, pickle, pdf
 FROM invoice
 WHERE period_start >= ?
-    AND period_end < ?
+    AND period_start < ?
 """
 
 _DELETE_INVOICE_QUERY = """\
@@ -166,8 +166,8 @@ class Store:
         self, financial_year: int
     ) -> list[tuple[Invoice, bytes]]:
         """Return list of (Invoice, pdf_bytes) for a financial year."""
-        start_date = datetime.datetime(financial_year, 7, 1)
-        end_date = datetime.datetime(financial_year + 1, 7, 1)
+        start_date = datetime.date(financial_year, 7, 1)
+        end_date = datetime.date(financial_year + 1, 7, 1)
         with self.connect() as db:
             rows = db.execute(
                 _GET_FY_INVOICES_PDF_QUERY, (start_date, end_date)
@@ -248,8 +248,8 @@ class Store:
             )
 
     def get_invoices(self, financial_year: int) -> list[dict[str, Any]]:
-        start_date = datetime.datetime(financial_year, 7, 1)
-        end_date = datetime.datetime(financial_year + 1, 7, 1)
+        start_date = datetime.date(financial_year, 7, 1)
+        end_date = datetime.date(financial_year + 1, 7, 1)
         with self.connect() as db:
             rows = db.execute(_INVOICES_QUERY, (start_date, end_date)).fetchall()
 

--- a/clockify_invoice/store.py
+++ b/clockify_invoice/store.py
@@ -29,11 +29,11 @@ WHERE user = ?
 GROUP BY description
 """
 
-_INVOCES_QUERY = """\
+_INVOICES_QUERY = """\
 SELECT id, pickle
 FROM invoice
-WHERE period_start > ?
-    AND period_end < ?
+WHERE period_start >= ?
+    AND period_end <= ?
 """
 
 _GET_INVOICE_QUERY = """\
@@ -45,8 +45,8 @@ WHERE id = ?
 _GET_FY_INVOICES_PDF_QUERY = """\
 SELECT id, pickle, pdf
 FROM invoice
-WHERE period_start > ?
-    AND period_end < ?
+WHERE period_start >= ?
+    AND period_end <= ?
 """
 
 _DELETE_INVOICE_QUERY = """\
@@ -163,8 +163,8 @@ class Store:
         self, financial_year: int
     ) -> list[tuple[Invoice, bytes]]:
         """Return list of (Invoice, pdf_bytes) for a financial year."""
-        start_date = datetime.datetime(financial_year, 6, 30)
-        end_date = datetime.datetime(financial_year + 1, 7, 1)
+        start_date = datetime.datetime(financial_year, 7, 1)
+        end_date = datetime.datetime(financial_year + 1, 6, 30)
         with self.connect() as db:
             rows = db.execute(
                 _GET_FY_INVOICES_PDF_QUERY, (start_date, end_date)
@@ -214,8 +214,8 @@ class Store:
             invoice.invoice_date,
             invoice.period_start,
             invoice.period_end,
-            invoice.company.name,
             invoice.client.name,
+            invoice.company.name,
             invoice.total,
             0,
             base64.b64encode(invoice.pdf()).decode(),
@@ -240,10 +240,10 @@ class Store:
             )
 
     def get_invoices(self, financial_year: int) -> list[dict[str, Any]]:
-        start_date = datetime.datetime(financial_year, 6, 30)
-        end_date = datetime.datetime(financial_year + 1, 7, 1)
+        start_date = datetime.datetime(financial_year, 7, 1)
+        end_date = datetime.datetime(financial_year + 1, 6, 30)
         with self.connect() as db:
-            rows = db.execute(_INVOCES_QUERY, (start_date, end_date)).fetchall()
+            rows = db.execute(_INVOICES_QUERY, (start_date, end_date)).fetchall()
 
         invoices: list[dict[str, Any]] = []
 

--- a/clockify_invoice/store.py
+++ b/clockify_invoice/store.py
@@ -36,6 +36,19 @@ WHERE period_start > ?
     AND period_end < ?
 """
 
+_GET_INVOICE_QUERY = """\
+SELECT pickle, pdf
+FROM invoice
+WHERE id = ?
+"""
+
+_GET_FY_INVOICES_PDF_QUERY = """\
+SELECT id, pickle, pdf
+FROM invoice
+WHERE period_start > ?
+    AND period_end < ?
+"""
+
 _DELETE_INVOICE_QUERY = """\
 DELETE
 FROM INVOICE
@@ -134,6 +147,35 @@ class Store:
         with contextlib.closing(sqlite3.connect(path)) as db:
             with db:
                 yield db
+
+    def get_invoice_by_id(self, invoice_id: int) -> tuple[Invoice, bytes] | None:
+        """Return (Invoice, pdf_bytes) for a given invoice ID, or None."""
+        with self.connect() as db:
+            row = db.execute(_GET_INVOICE_QUERY, (invoice_id,)).fetchone()
+        if not row:
+            return None
+        pickle_bytes = base64.b64decode(row[0])
+        invoice: Invoice = pickle.loads(pickle_bytes)
+        pdf_bytes = base64.b64decode(row[1])
+        return invoice, pdf_bytes
+
+    def get_fy_invoices_with_pdf(
+        self, financial_year: int
+    ) -> list[tuple[Invoice, bytes]]:
+        """Return list of (Invoice, pdf_bytes) for a financial year."""
+        start_date = datetime.datetime(financial_year, 6, 30)
+        end_date = datetime.datetime(financial_year + 1, 7, 1)
+        with self.connect() as db:
+            rows = db.execute(
+                _GET_FY_INVOICES_PDF_QUERY, (start_date, end_date)
+            ).fetchall()
+        results: list[tuple[Invoice, bytes]] = []
+        for row in rows:
+            pickle_bytes = base64.b64decode(row[1])
+            invoice: Invoice = pickle.loads(pickle_bytes)
+            pdf_bytes = base64.b64decode(row[2])
+            results.append((invoice, pdf_bytes))
+        return results
 
     def delete_invoice(self, id: int) -> None:
         with self.connect() as db:

--- a/clockify_invoice/templates/index.html
+++ b/clockify_invoice/templates/index.html
@@ -116,6 +116,12 @@
   </head>
   <body>
     <div class="container-lg">
+      {% if error %}
+      <div class="alert alert-danger alert-dismissible fade show mt-2" role="alert">
+        {{ error }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+      </div>
+      {% endif %}
       <div class="row">
         <div
           class="col-md-4 my-2"

--- a/clockify_invoice/templates/index.html
+++ b/clockify_invoice/templates/index.html
@@ -237,7 +237,9 @@
         }
       }
     }
-    setTab('{{form_data['active-tab']}}');
+    setTab('{{form_data.get('active-tab', '')}}');
+    {% if 'year' in form_data %}
     document.getElementById('financial-year').setAttribute('value', {{ form_data['year'] }});
+    {% endif %}
   </script>
 </html>

--- a/clockify_invoice/templates/invoice.html
+++ b/clockify_invoice/templates/invoice.html
@@ -113,6 +113,7 @@
                 document.getElementById('invoice-form').submit();
             }
         </script>
+        {% if 'financial-year' in form_data %}
         <div class="input-group mt-2">
             <div class="input-group-prepend">
                 <span class="input-group-text">Financial Year</span>
@@ -158,6 +159,7 @@
                 Summary
             </a>
         </div>
+        {% endif %}
         <div class="table-responsive">
             <table class="table table-hover ">
             <caption>{{ "$%.2f" | format(invoices_total) }}</caption>

--- a/clockify_invoice/templates/invoice.html
+++ b/clockify_invoice/templates/invoice.html
@@ -109,6 +109,7 @@
             function submitInvoiceForm(financialYear) {
                 document.getElementById('financial-year').value = financialYear;
                 document.getElementById('download-fy-zip').href = '/download_fy/' + financialYear;
+                document.getElementById('download-fy-summary').href = '/summary/' + financialYear;
                 document.getElementById('invoice-form').submit();
             }
         </script>
@@ -143,6 +144,18 @@
                     <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1h-2v1h-1v1h1v1h-1v1h1v1H6V5H5V4h1V3H5V2h1V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5z"/>
                 </svg>
                 ZIP
+            </a>
+            <a
+                class="btn btn-sm btn-info"
+                id="download-fy-summary"
+                href="{{ url_for('download_summary', year=form_data['financial-year'] | int) }}"
+                title="Download Summary (PDF)"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-pdf" viewBox="0 0 16 16">
+                    <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5z"/>
+                    <path d="M4.603 14.087a.8.8 0 0 1-.438-.42c-.195-.388-.13-.776.08-1.102.198-.307.526-.568.897-.787a7.7 7.7 0 0 1 1.482-.645 20 20 0 0 0 1.062-2.227 7.3 7.3 0 0 1-.43-1.295c-.086-.4-.119-.796-.046-1.136.075-.354.274-.672.65-.823.192-.077.4-.12.602-.077a.7.7 0 0 1 .477.365c.088.164.12.356.127.538.007.188-.012.396-.047.614-.084.51-.27 1.134-.52 1.794a11 11 0 0 0 .98 1.686 5.8 5.8 0 0 1 1.334.05c.364.066.734.195.96.465.12.144.193.32.2.518.007.192-.047.382-.138.563a1.04 1.04 0 0 1-.354.416.86.86 0 0 1-.51.138c-.331-.014-.654-.196-.933-.417a6.1 6.1 0 0 1-.911-.95 11.7 11.7 0 0 0-1.997.406 11.3 11.3 0 0 1-1.02 1.51c-.292.35-.609.656-.927.787a.8.8 0 0 1-.58.029z"/>
+                </svg>
+                Summary
             </a>
         </div>
         <div class="table-responsive">

--- a/clockify_invoice/templates/invoice.html
+++ b/clockify_invoice/templates/invoice.html
@@ -268,6 +268,23 @@
                 </table>
             </td>
         </tr>
+        {% if invoice['company'].bank_details %}
+        <tr class="information">
+            <td colspan="5">
+                <table>
+                    <tr>
+                        <td>
+                            <b>Payment Details</b><br />
+                            Account Name: {{invoice['company'].bank_details.account_name}}<br />
+                            BSB: {{invoice['company'].bank_details.bsb}}<br />
+                            Account: {{invoice['company'].bank_details.account_number}}
+                        </td>
+                        <td></td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        {% endif %}
         <tr class="details">
             <td colspan="4">
             For the period:<br />

--- a/clockify_invoice/templates/invoice.html
+++ b/clockify_invoice/templates/invoice.html
@@ -27,6 +27,20 @@
           </div>
       </div>
       <div class="mb-2">
+          <div class="input-group mb-3">
+            <span class="input-group-text">Invoice Date</span>
+            <input
+              type="date"
+              class="form-control form-control-sm"
+              id="invoice-date"
+              name="invoice-date"
+              value="{{form_data['invoice-date']}}"
+              onchange="setStatus()"
+              required
+            />
+          </div>
+      </div>
+      <div class="mb-2">
           <label for="month" class="form-label">For The Month</label>
           <div class="input-group">
             <select
@@ -94,6 +108,7 @@
         <script>
             function submitInvoiceForm(financialYear) {
                 document.getElementById('financial-year').value = financialYear;
+                document.getElementById('download-fy-zip').href = '/download_fy/' + financialYear;
                 document.getElementById('invoice-form').submit();
             }
         </script>
@@ -104,6 +119,7 @@
             <select
                 class="form-select form-select-sm"
                 aria-label="form-select-sm"
+                id="fy-select"
                 onchange="submitInvoiceForm(this.value)"
                 required
             >
@@ -116,6 +132,18 @@
                     </option>
                 {% endfor %}
             </select>
+            <a
+                class="btn btn-sm btn-success"
+                id="download-fy-zip"
+                href="{{ url_for('download_fy', year=form_data['financial-year'] | int) }}"
+                title="Download All (ZIP)"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-zip" viewBox="0 0 16 16">
+                    <path d="M5 7.5a1 1 0 0 1 1-1h1a1 1 0 0 1 1 1v.938l.4 1.599a1 1 0 0 1-.416 1.074l-.93.62a1 1 0 0 1-1.11 0l-.929-.62a1 1 0 0 1-.415-1.074L5 8.438zm2 0H6v.938a1 1 0 0 1-.03.243l-.4 1.598.93.62.929-.62-.4-1.598A1 1 0 0 1 7 8.438z"/>
+                    <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1h-2v1h-1v1h1v1h-1v1h1v1H6V5H5V4h1V3H5V2h1V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5z"/>
+                </svg>
+                ZIP
+            </a>
         </div>
         <div class="table-responsive">
             <table class="table table-hover ">
@@ -126,6 +154,8 @@
                 <th>#</th>
                 <th>Month</th>
                 <th>Total</th>
+                <th></th>
+                <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -144,6 +174,22 @@
                     <td>{{invoice.invoice_number}}</td>
                     <td>{{invoice.period_start.strftime('%b %Y')}}</td>
                     <td>{{ "$%.2f" | format(invoice.total) }}</td>
+                    <td>
+                        <a class="btn btn-sm btn-primary" href="{{ url_for('view_invoice', invoice_id=invoice['invoice_id']) }}" target="_blank" title="View">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-eye" viewBox="0 0 16 16">
+                                <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8M1.173 8a13 13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5s3.879 1.168 5.168 2.457A13 13 0 0 1 14.828 8q-.086.13-.195.288c-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5s-3.879-1.168-5.168-2.457A13 13 0 0 1 1.172 8z"/>
+                                <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5M4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0"/>
+                            </svg>
+                        </a>
+                    </td>
+                    <td>
+                        <a class="btn btn-sm btn-success" href="{{ url_for('download_invoice', invoice_id=invoice['invoice_id']) }}" title="Download">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download" viewBox="0 0 16 16">
+                                <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5"/>
+                                <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708z"/>
+                            </svg>
+                        </a>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/clockify_invoice/templates/invoice.html
+++ b/clockify_invoice/templates/invoice.html
@@ -116,7 +116,7 @@
         {% if 'financial-year' in form_data %}
         <div class="input-group mt-2">
             <div class="input-group-prepend">
-                <span class="input-group-text">Financial Year</span>
+                <span class="input-group-text">FY</span>
             </div>
             <select
                 class="form-select form-select-sm"

--- a/clockify_invoice/templates/summary.html
+++ b/clockify_invoice/templates/summary.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Invoice Summary — FY {{ year }}-{{ next_yy }}</title>
+    <style>
+      @page {
+        size: a4 portrait;
+        margin: 20mm;
+      }
+
+      body {
+        font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        line-height: 20px;
+        color: #555;
+      }
+
+      .summary-box {
+        max-width: 800px;
+        margin: auto;
+        padding: 30px;
+      }
+
+      .summary-box .title {
+        font-size: 36px;
+        line-height: 42px;
+        color: #333;
+        margin-bottom: 5px;
+      }
+
+      .summary-box .subtitle {
+        font-size: 18px;
+        color: #777;
+        margin-bottom: 30px;
+      }
+
+      .summary-box .company-name {
+        font-size: 14px;
+        color: #999;
+        margin-bottom: 30px;
+      }
+
+      .summary-box table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: left;
+      }
+
+      .summary-box table thead th {
+        background: #eee;
+        border-bottom: 1px solid #ddd;
+        font-weight: bold;
+        padding: 8px 10px;
+      }
+
+      .summary-box table thead th:last-child {
+        text-align: right;
+      }
+
+      .summary-box table tbody td {
+        padding: 8px 10px;
+        border-bottom: 1px solid #eee;
+      }
+
+      .summary-box table tbody td:last-child {
+        text-align: right;
+      }
+
+      .summary-box table tfoot td {
+        padding: 10px;
+        font-weight: bold;
+        font-size: 16px;
+        border-top: 2px solid #eee;
+      }
+
+      .summary-box table tfoot td:last-child {
+        text-align: right;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="summary-box">
+      <div class="title">Invoice Summary</div>
+      <div class="subtitle">FY {{ year }}-{{ next_yy }}</div>
+      <div class="company-name">{{ company_name }}</div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Invoice #</th>
+            <th>Date</th>
+            <th>Period</th>
+            <th>Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for inv in invoices %}
+          <tr>
+            <td>{{ inv.invoice_number }}</td>
+            <td>{{ inv.invoice_date.strftime('%d/%m/%Y') }}</td>
+            <td>{{ inv.period_start.strftime('%d/%m/%Y') }} — {{ inv.period_end.strftime('%d/%m/%Y') }}</td>
+            <td>${{ "%.2f" | format(inv.total) }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="3">Grand Total</td>
+            <td>${{ "%.2f" | format(grand_total) }}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </body>
+</html>

--- a/clockify_invoice/utils.py
+++ b/clockify_invoice/utils.py
@@ -84,6 +84,58 @@ def synch_workspaces(api_session: ClockifyClient, db: sqlite3.Connection) -> Non
     db.executemany("INSERT INTO workspace VALUES(?,?)", workspaces_data)
 
 
+def _split_entry_by_month(
+    entry_id: str,
+    start_time: datetime,
+    end_time: datetime,
+    desc: str,
+    user_id: str,
+    workspace_id: str,
+) -> list[tuple[Any, ...]]:
+    """Split a time entry at month boundaries into one or more DB rows."""
+    segments = []
+    seg_start = start_time
+    while True:
+        if seg_start.month == 12:
+            next_month = seg_start.replace(
+                year=seg_start.year + 1,
+                month=1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+        else:
+            next_month = seg_start.replace(
+                month=seg_start.month + 1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+        seg_end = min(end_time, next_month)
+        segments.append((seg_start, seg_end))
+        if seg_end >= end_time:
+            break
+        seg_start = next_month
+
+    fmt = Store._DATE_FORMAT
+    return [
+        (
+            entry_id if len(segments) == 1 else f"{entry_id}_{i}",
+            datetime.strftime(s, fmt),
+            datetime.strftime(e, fmt),
+            (e - s).total_seconds(),
+            desc,
+            user_id,
+            workspace_id,
+        )
+        for i, (s, e) in enumerate(segments)
+    ]
+
+
 def synch_time_entries(
     api_session: ClockifyClient,
     db: sqlite3.Connection,
@@ -109,23 +161,12 @@ def synch_time_entries(
 
         entry_id = te["id"]
         desc = te["description"]
-        start = te["timeInterval"]["start"]
-        start_time = _convert_datestr(start)
+        start_time = _convert_datestr(te["timeInterval"]["start"])
         end_time = _convert_datestr(end)
-        start_time_formatted = datetime.strftime(start_time, Store._DATE_FORMAT)
-        end_time_formatted = datetime.strftime(end_time, Store._DATE_FORMAT)
 
-        duration_secs = (end_time - start_time).total_seconds()
-
-        data.append(
-            (
-                entry_id,
-                start_time_formatted,
-                end_time_formatted,
-                duration_secs,
-                desc,
-                user_id,
-                workspace_id,
+        data.extend(
+            _split_entry_by_month(
+                entry_id, start_time, end_time, desc, user_id, workspace_id
             )
         )
     db.executemany("INSERT INTO time_entry VALUES(?,?,?,?,?,?,?)", data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clockify_invoice
-version = 2.3.1
+version = 2.4.0
 description = Create an invoice using clockifys API
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ console_scripts =
 clockify_invoice =
     templates/index.html
     templates/invoice.html
+    templates/summary.html
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
## Summary
- Invoice date picker — defaults to today, fully editable
- View/re-download buttons per saved invoice row
- FY ZIP download — bundles all invoices for a financial year
- FY summary PDF download
- Bank details shown on invoices
- API pagination fix — fetches all Clockify time entries (previously capped at 50, causing inconsistent invoice amounts)
- Rename \"Financial Year\" → \"FY\" throughout UI
- Fix half-open FY date bounds to correctly include June invoices
- Fix template guard for `form_data` references during PDF rendering

## Changes
- `api.py`: paginated `get_time_entries()` — loops all pages until exhausted
- `main.py`: new routes `/invoice/<id>`, `/download/<id>`, `/download_fy/<year>`, `/summary/<year>`
- `store.py`: new methods `get_invoice_by_id()`, `get_fy_invoices_with_pdf()`; fix FY date bounds
- `config.py`: load and expose `bank_details` from config
- `templates/invoice.html`: date input, view/download/ZIP buttons, bank details section

## Test plan
- [ ] Sync Clockify data and verify all time entries are fetched (>50 entries in account)
- [ ] Generate invoice for a month and confirm total is consistent across multiple syncs
- [ ] Date picker defaults to today; changing it persists on save
- [ ] View/download buttons open correct saved invoices
- [ ] FY ZIP contains all invoices for the selected year
- [ ] FY summary PDF renders correctly
- [ ] Bank details appear on generated invoice PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)